### PR TITLE
More optional parameters for global fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -176,6 +176,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "abortcontroller-polyfill": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz",
+      "integrity": "sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA=="
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "mocha build -t 10000"
   },
   "dependencies": {
+    "abortcontroller-polyfill": "^1.4.0",
     "fable-compiler": "^2.3.19",
     "fable-compiler-js": "^1.0.5",
     "fable-publish-utils": "^1.0.5",

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -60,6 +60,16 @@ module Types =
         | [<CompiledName("force-cache")>]Forcecache
         | [<CompiledName("only-if-cached")>]Onlyifcached
 
+    and [<StringEnum; RequireQualifiedAccess>] RedirectMode =
+        | Follow | Error | Manual
+
+    and [<StringEnum; RequireQualifiedAccess>] ReferrerPolicy =
+        | [<CompiledName("no-referrer")>]NoReferrer
+        | [<CompiledName("no-referrer-when-downgrade")>]NoReferrerWhenDowngrade
+        | Origin
+        | [<CompiledName("origin-when-cross-origin")>]OriginWhenCrossOrigin
+        | [<CompiledName("unsafe-url")>]UnsafeUrl
+
     and Headers =
         abstract append : string * string -> unit
         abstract delete : string -> unit
@@ -325,6 +335,14 @@ module Types =
         | [<CompiledName("X-Csrf-Token")>] XCsrfToken of string
         | [<Erase>] Custom of key:string * value:obj
 
+    type AbortSignal =
+      abstract aborted : bool with get
+      abstract onabort : (unit -> unit) with get, set
+
+    type AbortController =
+      abstract signal : AbortSignal with get
+      abstract abort : (unit -> unit) with get
+
     [<NoComparison>]
     type RequestProperties =
         | Method of HttpMethod
@@ -333,7 +351,15 @@ module Types =
         | Mode of RequestMode
         | Credentials of RequestCredentials
         | Cache of RequestCache
+        | Redirect of RedirectMode
+        | Referrer of string
+        | ReferrerPolicy of ReferrerPolicy
+        | Integrity of string
+        | KeepAlive of bool
+        | Signal of AbortSignal
 
+[<Emit("new AbortController()")>]
+let newAbortController () : AbortController = jsNative
 
 let inline requestHeaders (headers: HttpRequestHeaders list) =
     RequestProperties.Headers(keyValueList CaseRules.None headers :?> IHttpRequestHeaders)


### PR DESCRIPTION
This extends the functionality to all of the possible options specified in the [MDN reference](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch)

This also enables aborting the fetch using a signal, as discussed in issue #3 