### PR TITLE
Do not modify non-Ok fetch return

### DIFF
--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -367,9 +367,16 @@ let inline requestHeaders (headers: HttpRequestHeaders list) =
 let inline requestProps (props: RequestProperties list) =
     keyValueList CaseRules.LowerFirst props :?> RequestInit
 
-/// Retrieves data from the specified resource.
+let private errorString (response: Response) =
+    string response.Status + " " + response.StatusText + " for URL " + response.Url
+
+/// Retrieves data from the specified resource. Fails if `response.Ok` evals to false.
 let fetch (url: string) (init: RequestProperties list) : JS.Promise<Response> =
     GlobalFetch.fetch(RequestInfo.Url url, requestProps init)
+    |> Promise.map (fun response ->
+        if response.Ok
+        then response
+        else errorString response |> failwith)
 
 let tryFetch (url: string) (init: RequestProperties list) : JS.Promise<Result<Response, Exception>> =
     fetch url init |> Promise.result

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -378,6 +378,10 @@ let fetch (url: string) (init: RequestProperties list) : JS.Promise<Response> =
         then response
         else errorString response |> failwith)
 
+/// Retrieves data from the specified resource without check for 2xx status.
+let fetchUnsafe (url: string) (init: RequestProperties list) : JS.Promise<Response> =
+    GlobalFetch.fetch(RequestInfo.Url url, requestProps init)
+
 let tryFetch (url: string) (init: RequestProperties list) : JS.Promise<Result<Response, Exception>> =
     fetch url init |> Promise.result
 

--- a/src/Fetch.fs
+++ b/src/Fetch.fs
@@ -367,16 +367,9 @@ let inline requestHeaders (headers: HttpRequestHeaders list) =
 let inline requestProps (props: RequestProperties list) =
     keyValueList CaseRules.LowerFirst props :?> RequestInit
 
-let private errorString (response: Response) =
-    string response.Status + " " + response.StatusText + " for URL " + response.Url
-
-/// Retrieves data from the specified resource. Fails if `response.Ok` evals to false.
+/// Retrieves data from the specified resource.
 let fetch (url: string) (init: RequestProperties list) : JS.Promise<Response> =
     GlobalFetch.fetch(RequestInfo.Url url, requestProps init)
-    |> Promise.map (fun response ->
-        if response.Ok
-        then response
-        else errorString response |> failwith)
 
 let tryFetch (url: string) (init: RequestProperties list) : JS.Promise<Result<Response, Exception>> =
     fetch url init |> Promise.result

--- a/tests/FetchTests.fs
+++ b/tests/FetchTests.fs
@@ -188,6 +188,20 @@ describe "Fetch tests" <| fun _ ->
         abortController.abort()
         promise
 
+    it "fetchUnsafe: invalid URL returns 404 (Not Found)" <| fun () ->
+        promise {
+            let! res = fetchUnsafe "https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
+            return res.Status
+        }
+        |> Promise.map (fun results -> results |> equal 404)
+
+    it "fetchUnsafe: HTTP OPTIONS request on Fable.io returns 405 (Method not allowed)" <| fun () ->
+        promise {
+            let! res = fetchUnsafe "https://fable.io" [ RequestProperties.Method HttpMethod.OPTIONS ]
+            return res.Status
+        }
+        |> Promise.map (fun results -> results |> equal 405)
+
     // it "fetchAs: works with manual decoder" <| fun () ->
     //     fetchAs "https://randomuser.me/api" RandomUser.ApiResult.Decoder []
     //     |> Promise.map (fun result ->

--- a/tests/FetchTests.fs
+++ b/tests/FetchTests.fs
@@ -16,66 +16,6 @@ let it (msg: string) (f: unit->JS.Promise<'T>): unit = jsNative
 [<Global>]
 let describe (msg: string) (f: unit->unit): unit = jsNative
 
-// module RandomUser =
-
-//     type UserName =
-//         { Title : string
-//           First : string
-//           Last : string }
-
-//         static member Decoder =
-//             Decode.object (fun get ->
-//                 { Title = get.Required.Field "title" Decode.string
-//                   First = get.Required.Field "first" Decode.string
-//                   Last = get.Required.Field "last" Decode.string } : UserName
-//             )
-
-//     type UserDob =
-//         { Date : string
-//           Age : int }
-
-//         static member Decoder =
-//             Decode.object (fun get ->
-//                 { Date = get.Required.Field "date" Decode.string
-//                   Age = get.Required.Field "age" Decode.int } : UserDob
-//             )
-
-//     type User =
-//         { Gender : string
-//           Name : UserName
-//           Dob : UserDob }
-
-//         static member Decoder =
-//             Decode.object (fun get ->
-//                 { Gender = get.Required.Field "gender" Decode.string
-//                   Name = get.Required.Field "name" UserName.Decoder
-//                   Dob = get.Required.Field "dob" UserDob.Decoder } : User
-//             )
-
-//     type ApiInfo =
-//         { Seed : string
-//           Results : int
-//           Page : int
-//           Version : string }
-
-//         static member Decoder =
-//             Decode.object (fun get ->
-//                 { Seed = get.Required.Field "seed" Decode.string
-//                   Results = get.Required.Field "results" Decode.int
-//                   Page = get.Required.Field "page" Decode.int
-//                   Version = get.Required.Field "version" Decode.string } : ApiInfo
-//             )
-
-//     type ApiResult =
-//         { Results : User list
-//           Info : ApiInfo }
-
-//         static member Decoder =
-//             Decode.object (fun get ->
-//                 { Results = get.Required.Field "results" (Decode.list User.Decoder)
-//                   Info = get.Required.Field "info" ApiInfo.Decoder } : ApiResult
-//             )
-
 describe "Fetch tests" <| fun _ ->
     it "fetch: requests work" <| fun () ->
         let getWebPageLength url =
@@ -101,26 +41,14 @@ describe "Fetch tests" <| fun _ ->
         // expected to be bigger than 100 characters
         |> Promise.map (fun results -> (Array.sum results) > 100 |> equal true)
 
-    it "fetch: unsuccessful HTTP status codes throw an error" <| fun () ->
+    it "fetch: invalid URL returns 404 (Not Found)" <| fun () ->
         promise {
             let! res = fetch "https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
-            let! txt = res.text()
-            return txt
+            return res.Status
         }
-        |> Promise.catch (fun e -> e.Message)
-        |> Promise.map (fun results ->
-            results |> equal "404 Not Found for URL https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
+        |> Promise.map (fun results -> results |> equal 404)
 
-    it "tryFetch: unsuccessful HTTP status codes returns an Error" <| fun () ->
-        tryFetch "https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
-        |> Promise.map (fun a ->
-            match a with
-            | Ok a -> "failed"
-            | Error e -> e.Message)
-        |> Promise.map (fun results ->
-            results |> equal "404 Not Found for URL https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
-
-    it "tryFetch: Successful HTTP OPTIONS request" <| fun () ->
+    it "tryFetch: successful HTTP OPTIONS request" <| fun () ->
         let successMessage = "OPTIONS request accepted (method allowed)"
         let props = [ RequestProperties.Method HttpMethod.OPTIONS]
         tryFetch "https://gandi.net" props
@@ -128,48 +56,41 @@ describe "Fetch tests" <| fun _ ->
             match a with
             | Ok _ -> successMessage
             | Error e -> e.Message)
-        |> Promise.map (fun results ->
-            results |> equal successMessage)
+        |> Promise.map (fun results -> results |> equal successMessage)
 
-    it "tryFetch: Failed HTTP OPTIONS request on Fable.io server" <| fun () ->
-        let failMessage = "OPTIONS request rejected (method not allowed)"
+    it "tryFetch: HTTP OPTIONS request on Fable.io returns 405 (Method not allowed)" <| fun () ->
         let props = [ RequestProperties.Method HttpMethod.OPTIONS]
         tryFetch "https://fable.io" props
         |> Promise.map (fun a ->
             match a with
-            | Ok a -> "ohoh? Fable.io allows OPTIONS request?"
-            | Error e -> failMessage)
-        |> Promise.map (fun results ->
-            results |> equal failMessage)
+            | Ok a -> a.Status
+            | Error _ -> -1)
+        |> Promise.map (fun results -> results |> equal 405)
 
-    it "tryFetch: exceptions return an Error" <| fun () ->
+    it "tryFetch: exception returns an Error" <| fun () ->
         tryFetch "http://this-must-be-an-invalid-url-no-really-i-mean-it.com" []
         |> Promise.map (fun a ->
             match a with
-            | Ok a -> "success"
-            | Error e -> "failure")
-        |> Promise.map (fun results ->
-            results |> equal "failure")
+            | Ok _ -> "success"
+            | Error _ -> "failure")
+        |> Promise.map (fun results -> results |> equal "failure")
 
-    it "tryOptionsRequest: Successful HTTP OPTIONS request" <| fun () ->
+    it "tryOptionsRequest: successful HTTP OPTIONS request" <| fun () ->
         let successMessage = "OPTIONS request accepted (method allowed)"
         tryOptionsRequest "https://gandi.net"
         |> Promise.map (fun a ->
             match a with
             | Ok _ -> successMessage
             | Error e -> e.Message)
-        |> Promise.map (fun results ->
-            results |> equal successMessage)
+        |> Promise.map (fun results -> results |> equal successMessage)
 
-    it "tryOptionsRequest: Failed HTTP OPTIONS request on Fable.io server" <| fun () ->
-        let failMessage = "OPTIONS request rejected (method not allowed)"
+    it "tryOptionsRequest: HTTP OPTIONS request on Fable.io returns 405 (Method not allowed)" <| fun () ->
         tryOptionsRequest "https://fable.io"
         |> Promise.map (fun a ->
             match a with
-            | Ok a -> "ohoh? Fable.io allows OPTIONS request?"
-            | Error e -> failMessage)
-        |> Promise.map (fun results ->
-            results |> equal failMessage)
+            | Ok a -> a.Status
+            | Error _ -> -1)
+        |> Promise.map (fun results -> results |> equal 405)
 
     it "fetch: request can be aborted" <| fun () ->
         let abortController = newAbortController()
@@ -180,101 +101,9 @@ describe "Fetch tests" <| fun _ ->
           tryFetch "https://fable.io" props
           |> Promise.map (function
               | Error e when e.Message = "Aborted" -> failMessage
-              | Ok a -> "Request was never cancelled"
-              | Error e -> "Something else went wrong")
-          |> Promise.map (fun results ->
-              results |> equal failMessage)
+              | Ok _ -> "Request was never cancelled"
+              | Error _ -> "Something else went wrong")
+          |> Promise.map (fun results -> results |> equal failMessage)
 
         abortController.abort()
         promise
-
-    // it "fetchAs: works with manual decoder" <| fun () ->
-    //     fetchAs "https://randomuser.me/api" RandomUser.ApiResult.Decoder []
-    //     |> Promise.map (fun result ->
-    //         equal result.Info.Page 1
-    //     )
-
-    // it "fetchAs: fails if the decoder fail" <| fun () ->
-    //     fetchAs "https://randomuser.me/api" RandomUser.UserName.Decoder []
-    //     |> Promise.map (fun user ->
-    //         user.First
-    //     )
-    //     |> Promise.catch (fun error ->
-    //         error.Message
-    //     )
-    //     |> Promise.map(fun res ->
-    //         res.StartsWith("Error at: `$.title`\nExpecting an object with a field named `title` but instead got:")
-    //         |> equal true
-    //     )
-
-    // it "fetchAs: works with auto decoder" <| fun () ->
-    //     let apiResultDecoder = Decode.Auto.generateDecoder<RandomUser.ApiResult>(isCamelCase = true)
-    //     fetchAs "https://randomuser.me/api" apiResultDecoder []
-    //     |> Promise.map (fun result ->
-    //         equal result.Info.Page 1
-    //     )
-
-    // it "fetchAs: fails if the auto decoder fail" <| fun () ->
-    //     let userNameDecoder = Decode.Auto.generateDecoder<RandomUser.UserName>(isCamelCase = true)
-    //     fetchAs "https://randomuser.me/api" userNameDecoder []
-    //     |> Promise.map (fun user ->
-    //         user.First
-    //     )
-    //     |> Promise.catch (fun error ->
-    //         error.Message
-    //     )
-    //     |> Promise.map(fun res ->
-    //         res.StartsWith("Error at: `$.last`\nExpecting an object with a field named `last` but instead got:")
-    //         |> equal true
-    //     )
-
-    // it "tryFetchAs: works with manual decoder" <| fun () ->
-    //     tryFetchAs "https://randomuser.me/api" RandomUser.ApiResult.Decoder []
-    //     |> Promise.map (fun result ->
-    //         match result with
-    //         | Ok result ->
-    //             equal result.Info.Page 1
-    //         | Error _ ->
-    //             failwith "This test should succeed"
-    //     )
-
-    // it "tryFetchAs: fails if the decoder fail" <| fun () ->
-    //     tryFetchAs "https://randomuser.me/api" RandomUser.UserName.Decoder []
-    //     |> Promise.map (fun result ->
-    //         match result with
-    //         | Ok _ ->
-    //             failwith "This test should fail"
-    //         | Error msg -> msg
-    //     )
-    //     |> Promise.map(fun res ->
-    //         res.StartsWith("Error at: `$.title`\nExpecting an object with a field named `title` but instead got:")
-    //         |> equal true
-    //     )
-
-    // it "tryFetchAs: works with auto decoder" <| fun () ->
-    //     let apiResultDecoder = Decode.Auto.generateDecoder<RandomUser.ApiResult>(isCamelCase = true)
-    //     tryFetchAs "https://randomuser.me/api" apiResultDecoder []
-    //     |> Promise.map (fun result ->
-    //         match result with
-    //         | Ok result ->
-    //             equal result.Info.Page 1
-    //         | Error _ ->
-    //             failwith "This test should succeed"
-    //     )
-
-    // it "tryFetchAs: fails if the auto decoder fail" <| fun () ->
-    //     let userNameDecoder = Decode.Auto.generateDecoder<RandomUser.UserName>(isCamelCase = true)
-    //     tryFetchAs "https://randomuser.me/api" userNameDecoder []
-    //     |> Promise.map (fun result ->
-    //         match result with
-    //         | Ok _ ->
-    //             failwith "This test should fail"
-    //         | Error msg -> msg
-    //     )
-    //     |> Promise.catch (fun error ->
-    //         error.Message
-    //     )
-    //     |> Promise.map(fun res ->
-    //         res.StartsWith("Error at: `$.last`\nExpecting an object with a field named `last` but instead got:")
-    //         |> equal true
-    //     )

--- a/tests/FetchTests.fs
+++ b/tests/FetchTests.fs
@@ -63,9 +63,9 @@ describe "Fetch tests" <| fun _ ->
         tryFetch "https://fable.io" props
         |> Promise.map (fun a ->
             match a with
-            | Ok a -> a.Status
-            | Error _ -> -1)
-        |> Promise.map (fun results -> results |> equal 405)
+            | Ok a -> Some a.Status
+            | Error _ -> None)
+        |> Promise.map (fun results -> results |> equal (Some 405))
 
     it "tryFetch: exception returns an Error" <| fun () ->
         tryFetch "http://this-must-be-an-invalid-url-no-really-i-mean-it.com" []
@@ -88,9 +88,9 @@ describe "Fetch tests" <| fun _ ->
         tryOptionsRequest "https://fable.io"
         |> Promise.map (fun a ->
             match a with
-            | Ok a -> a.Status
-            | Error _ -> -1)
-        |> Promise.map (fun results -> results |> equal 405)
+            | Ok a -> Some a.Status
+            | Error _ -> None)
+        |> Promise.map (fun results -> results |> equal (Some 405))
 
     it "fetch: request can be aborted" <| fun () ->
         let abortController = newAbortController()

--- a/tests/FetchTests.fs
+++ b/tests/FetchTests.fs
@@ -16,6 +16,66 @@ let it (msg: string) (f: unit->JS.Promise<'T>): unit = jsNative
 [<Global>]
 let describe (msg: string) (f: unit->unit): unit = jsNative
 
+// module RandomUser =
+
+//     type UserName =
+//         { Title : string
+//           First : string
+//           Last : string }
+
+//         static member Decoder =
+//             Decode.object (fun get ->
+//                 { Title = get.Required.Field "title" Decode.string
+//                   First = get.Required.Field "first" Decode.string
+//                   Last = get.Required.Field "last" Decode.string } : UserName
+//             )
+
+//     type UserDob =
+//         { Date : string
+//           Age : int }
+
+//         static member Decoder =
+//             Decode.object (fun get ->
+//                 { Date = get.Required.Field "date" Decode.string
+//                   Age = get.Required.Field "age" Decode.int } : UserDob
+//             )
+
+//     type User =
+//         { Gender : string
+//           Name : UserName
+//           Dob : UserDob }
+
+//         static member Decoder =
+//             Decode.object (fun get ->
+//                 { Gender = get.Required.Field "gender" Decode.string
+//                   Name = get.Required.Field "name" UserName.Decoder
+//                   Dob = get.Required.Field "dob" UserDob.Decoder } : User
+//             )
+
+//     type ApiInfo =
+//         { Seed : string
+//           Results : int
+//           Page : int
+//           Version : string }
+
+//         static member Decoder =
+//             Decode.object (fun get ->
+//                 { Seed = get.Required.Field "seed" Decode.string
+//                   Results = get.Required.Field "results" Decode.int
+//                   Page = get.Required.Field "page" Decode.int
+//                   Version = get.Required.Field "version" Decode.string } : ApiInfo
+//             )
+
+//     type ApiResult =
+//         { Results : User list
+//           Info : ApiInfo }
+
+//         static member Decoder =
+//             Decode.object (fun get ->
+//                 { Results = get.Required.Field "results" (Decode.list User.Decoder)
+//                   Info = get.Required.Field "info" ApiInfo.Decoder } : ApiResult
+//             )
+
 describe "Fetch tests" <| fun _ ->
     it "fetch: requests work" <| fun () ->
         let getWebPageLength url =
@@ -41,14 +101,26 @@ describe "Fetch tests" <| fun _ ->
         // expected to be bigger than 100 characters
         |> Promise.map (fun results -> (Array.sum results) > 100 |> equal true)
 
-    it "fetch: invalid URL returns 404 (Not Found)" <| fun () ->
+    it "fetch: unsuccessful HTTP status codes throw an error" <| fun () ->
         promise {
             let! res = fetch "https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
-            return res.Status
+            let! txt = res.text()
+            return txt
         }
-        |> Promise.map (fun results -> results |> equal 404)
+        |> Promise.catch (fun e -> e.Message)
+        |> Promise.map (fun results ->
+            results |> equal "404 Not Found for URL https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
 
-    it "tryFetch: successful HTTP OPTIONS request" <| fun () ->
+    it "tryFetch: unsuccessful HTTP status codes returns an Error" <| fun () ->
+        tryFetch "https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it" []
+        |> Promise.map (fun a ->
+            match a with
+            | Ok a -> "failed"
+            | Error e -> e.Message)
+        |> Promise.map (fun results ->
+            results |> equal "404 Not Found for URL https://fable.io/this-must-be-an-invalid-url-no-really-i-mean-it")
+
+    it "tryFetch: Successful HTTP OPTIONS request" <| fun () ->
         let successMessage = "OPTIONS request accepted (method allowed)"
         let props = [ RequestProperties.Method HttpMethod.OPTIONS]
         tryFetch "https://gandi.net" props
@@ -56,41 +128,48 @@ describe "Fetch tests" <| fun _ ->
             match a with
             | Ok _ -> successMessage
             | Error e -> e.Message)
-        |> Promise.map (fun results -> results |> equal successMessage)
+        |> Promise.map (fun results ->
+            results |> equal successMessage)
 
-    it "tryFetch: HTTP OPTIONS request on Fable.io returns 405 (Method not allowed)" <| fun () ->
+    it "tryFetch: Failed HTTP OPTIONS request on Fable.io server" <| fun () ->
+        let failMessage = "OPTIONS request rejected (method not allowed)"
         let props = [ RequestProperties.Method HttpMethod.OPTIONS]
         tryFetch "https://fable.io" props
         |> Promise.map (fun a ->
             match a with
-            | Ok a -> Some a.Status
-            | Error _ -> None)
-        |> Promise.map (fun results -> results |> equal (Some 405))
+            | Ok a -> "ohoh? Fable.io allows OPTIONS request?"
+            | Error e -> failMessage)
+        |> Promise.map (fun results ->
+            results |> equal failMessage)
 
-    it "tryFetch: exception returns an Error" <| fun () ->
+    it "tryFetch: exceptions return an Error" <| fun () ->
         tryFetch "http://this-must-be-an-invalid-url-no-really-i-mean-it.com" []
         |> Promise.map (fun a ->
             match a with
-            | Ok _ -> "success"
-            | Error _ -> "failure")
-        |> Promise.map (fun results -> results |> equal "failure")
+            | Ok a -> "success"
+            | Error e -> "failure")
+        |> Promise.map (fun results ->
+            results |> equal "failure")
 
-    it "tryOptionsRequest: successful HTTP OPTIONS request" <| fun () ->
+    it "tryOptionsRequest: Successful HTTP OPTIONS request" <| fun () ->
         let successMessage = "OPTIONS request accepted (method allowed)"
         tryOptionsRequest "https://gandi.net"
         |> Promise.map (fun a ->
             match a with
             | Ok _ -> successMessage
             | Error e -> e.Message)
-        |> Promise.map (fun results -> results |> equal successMessage)
+        |> Promise.map (fun results ->
+            results |> equal successMessage)
 
-    it "tryOptionsRequest: HTTP OPTIONS request on Fable.io returns 405 (Method not allowed)" <| fun () ->
+    it "tryOptionsRequest: Failed HTTP OPTIONS request on Fable.io server" <| fun () ->
+        let failMessage = "OPTIONS request rejected (method not allowed)"
         tryOptionsRequest "https://fable.io"
         |> Promise.map (fun a ->
             match a with
-            | Ok a -> Some a.Status
-            | Error _ -> None)
-        |> Promise.map (fun results -> results |> equal (Some 405))
+            | Ok a -> "ohoh? Fable.io allows OPTIONS request?"
+            | Error e -> failMessage)
+        |> Promise.map (fun results ->
+            results |> equal failMessage)
 
     it "fetch: request can be aborted" <| fun () ->
         let abortController = newAbortController()
@@ -101,9 +180,101 @@ describe "Fetch tests" <| fun _ ->
           tryFetch "https://fable.io" props
           |> Promise.map (function
               | Error e when e.Message = "Aborted" -> failMessage
-              | Ok _ -> "Request was never cancelled"
-              | Error _ -> "Something else went wrong")
-          |> Promise.map (fun results -> results |> equal failMessage)
+              | Ok a -> "Request was never cancelled"
+              | Error e -> "Something else went wrong")
+          |> Promise.map (fun results ->
+              results |> equal failMessage)
 
         abortController.abort()
         promise
+
+    // it "fetchAs: works with manual decoder" <| fun () ->
+    //     fetchAs "https://randomuser.me/api" RandomUser.ApiResult.Decoder []
+    //     |> Promise.map (fun result ->
+    //         equal result.Info.Page 1
+    //     )
+
+    // it "fetchAs: fails if the decoder fail" <| fun () ->
+    //     fetchAs "https://randomuser.me/api" RandomUser.UserName.Decoder []
+    //     |> Promise.map (fun user ->
+    //         user.First
+    //     )
+    //     |> Promise.catch (fun error ->
+    //         error.Message
+    //     )
+    //     |> Promise.map(fun res ->
+    //         res.StartsWith("Error at: `$.title`\nExpecting an object with a field named `title` but instead got:")
+    //         |> equal true
+    //     )
+
+    // it "fetchAs: works with auto decoder" <| fun () ->
+    //     let apiResultDecoder = Decode.Auto.generateDecoder<RandomUser.ApiResult>(isCamelCase = true)
+    //     fetchAs "https://randomuser.me/api" apiResultDecoder []
+    //     |> Promise.map (fun result ->
+    //         equal result.Info.Page 1
+    //     )
+
+    // it "fetchAs: fails if the auto decoder fail" <| fun () ->
+    //     let userNameDecoder = Decode.Auto.generateDecoder<RandomUser.UserName>(isCamelCase = true)
+    //     fetchAs "https://randomuser.me/api" userNameDecoder []
+    //     |> Promise.map (fun user ->
+    //         user.First
+    //     )
+    //     |> Promise.catch (fun error ->
+    //         error.Message
+    //     )
+    //     |> Promise.map(fun res ->
+    //         res.StartsWith("Error at: `$.last`\nExpecting an object with a field named `last` but instead got:")
+    //         |> equal true
+    //     )
+
+    // it "tryFetchAs: works with manual decoder" <| fun () ->
+    //     tryFetchAs "https://randomuser.me/api" RandomUser.ApiResult.Decoder []
+    //     |> Promise.map (fun result ->
+    //         match result with
+    //         | Ok result ->
+    //             equal result.Info.Page 1
+    //         | Error _ ->
+    //             failwith "This test should succeed"
+    //     )
+
+    // it "tryFetchAs: fails if the decoder fail" <| fun () ->
+    //     tryFetchAs "https://randomuser.me/api" RandomUser.UserName.Decoder []
+    //     |> Promise.map (fun result ->
+    //         match result with
+    //         | Ok _ ->
+    //             failwith "This test should fail"
+    //         | Error msg -> msg
+    //     )
+    //     |> Promise.map(fun res ->
+    //         res.StartsWith("Error at: `$.title`\nExpecting an object with a field named `title` but instead got:")
+    //         |> equal true
+    //     )
+
+    // it "tryFetchAs: works with auto decoder" <| fun () ->
+    //     let apiResultDecoder = Decode.Auto.generateDecoder<RandomUser.ApiResult>(isCamelCase = true)
+    //     tryFetchAs "https://randomuser.me/api" apiResultDecoder []
+    //     |> Promise.map (fun result ->
+    //         match result with
+    //         | Ok result ->
+    //             equal result.Info.Page 1
+    //         | Error _ ->
+    //             failwith "This test should succeed"
+    //     )
+
+    // it "tryFetchAs: fails if the auto decoder fail" <| fun () ->
+    //     let userNameDecoder = Decode.Auto.generateDecoder<RandomUser.UserName>(isCamelCase = true)
+    //     tryFetchAs "https://randomuser.me/api" userNameDecoder []
+    //     |> Promise.map (fun result ->
+    //         match result with
+    //         | Ok _ ->
+    //             failwith "This test should fail"
+    //         | Error msg -> msg
+    //     )
+    //     |> Promise.catch (fun error ->
+    //         error.Message
+    //     )
+    //     |> Promise.map(fun res ->
+    //         res.StartsWith("Error at: `$.last`\nExpecting an object with a field named `last` but instead got:")
+    //         |> equal true
+    //     )


### PR DESCRIPTION
Currently caller of a fetch method doesn't have access to the actual response object if status is not 2xx and instead of response, exception with errorString is returned:

https://github.com/fable-compiler/fable-fetch/blob/b79a153b59f806771508fa36321221e5dc338269/src/Fetch.fs#L370-L379

This is very limiting as there might be need for custom response parsing on the client side.

This is related to issue https://github.com/fable-compiler/fable-fetch/issues/10#issue-617305041.